### PR TITLE
Adds Rake and Cultivator so players can be self sufficient in hermits garden.

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
@@ -69,6 +69,11 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass/fairy,
 /area/ruin/powered/hermit)
+"vy" = (
+/obj/item/cultivator/rake,
+/obj/item/cultivator,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
 "wf" = (
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
 /obj/structure/table/wood,
@@ -326,7 +331,7 @@ ph
 ph
 uw
 bp
-bp
+vy
 bp
 WK
 gr


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added both a rake and a cultivator to the icemoon underground hermit ruin structure. This is to allow complete ability to operate without extra tools from external sources. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It means ghosts(or visitors) can fully utilise this area and aren't hindered by being unable to remove any weeds etc.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

:cl: icequibe
add: Added more things
qol: made something easier to use
/:cl:
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
